### PR TITLE
Add superspace statistics

### DIFF
--- a/app/commands/decidim/superspaces/admin/create_superspace.rb
+++ b/app/commands/decidim/superspaces/admin/create_superspace.rb
@@ -58,7 +58,8 @@ module Decidim
             title: form.title,
             description: form.description,
             locale: form.locale,
-            hero_image: form.hero_image
+            hero_image: form.hero_image,
+            show_statistics: form.show_statistics
           }
 
           @superspace = Decidim.traceability.create!(

--- a/app/commands/decidim/superspaces/admin/update_superspace.rb
+++ b/app/commands/decidim/superspaces/admin/update_superspace.rb
@@ -44,7 +44,8 @@ module Decidim
             title: form.title,
             description: form.description,
             hero_image: form.hero_image,
-            locale: form.locale
+            locale: form.locale,
+            show_statistics: form.show_statistics
           )
           update_associations(assembly_ids, participatory_process_ids, conference_ids)
         end

--- a/app/forms/decidim/superspaces/admin/superspace_form.rb
+++ b/app/forms/decidim/superspaces/admin/superspace_form.rb
@@ -14,6 +14,7 @@ module Decidim
         attribute :assembly_ids
         attribute :participatory_process_ids
         attribute :conference_ids
+        attribute :show_statistics, Boolean
 
         validates :title, translatable_presence: true
         validates :locale, presence: true

--- a/app/models/decidim/superspaces/superspace.rb
+++ b/app/models/decidim/superspaces/superspace.rb
@@ -35,6 +35,10 @@ module Decidim
         find_spaces_by_type("Decidim::Conference")
       end
 
+      def statistics
+        Decidim::Superspaces::SuperspaceStatsPresenter.new(self).collection
+      end
+
       def self.log_presenter_class_for(_log) = Decidim::Superspaces::AdminLog::SuperspacePresenter
 
       private

--- a/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
+++ b/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
@@ -17,7 +17,7 @@ module Decidim
         Decidim::Superspaces::StatsParticipantsCount.for(participatory_space)
       end
 
-      def participatory_space_followers_stats(conditions)
+      def participatory_space_followers_stats(_conditions)
         Decidim::Superspaces::StatsFollowersCount.for(participatory_space)
       end
 

--- a/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
+++ b/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    class SuperspaceStatsPresenter < Decidim::StatsPresenter
+      include Decidim::IconHelper
+
+      private
+
+      def participatory_space = __getobj__
+
+      def participatory_processes
+        @participatory_processes ||= participatory_space.participatory_processes + participatory_space.assemblies + participatory_space.conferences
+      end
+
+      def participatory_space_participants_stats
+        Decidim::Superspaces::StatsParticipantsCount.for(participatory_space)
+      end
+
+      def participatory_space_followers_stats(conditions)
+        Decidim::Superspaces::StatsFollowersCount.for(participatory_space)
+      end
+
+      def published_components
+        @published_components ||= Component.where(participatory_space: participatory_processes).published
+      end
+
+      def participatory_space_sym = :superspace
+    end
+  end
+end

--- a/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
+++ b/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
@@ -9,6 +9,19 @@ module Decidim
     class SuperspaceStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
+      def collection
+        highlighted_stats = participatory_space_participants_stats
+        highlighted_stats.concat(participatory_space_followers_stats)
+        highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
+        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
+        highlighted_stats.concat(comments_stats(participatory_space_sym))
+        highlighted_stats = highlighted_stats.reject(&:empty?)
+        highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
+        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
+
+        statistics(grouped_highlighted_stats)
+      end
+
       private
 
       def participatory_space = __getobj__
@@ -21,7 +34,7 @@ module Decidim
         Decidim::Superspaces::StatsParticipantsCount.for(participatory_space)
       end
 
-      def participatory_space_followers_stats(_conditions)
+      def participatory_space_followers_stats
         Decidim::Superspaces::StatsFollowersCount.for(participatory_space)
       end
 

--- a/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
+++ b/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
@@ -2,7 +2,6 @@
 
 module Decidim
   module Superspaces
-    
     # This class holds the logic to present superspace stats.
     # It inherits from `Decidim::StatsPresenter` and overrides the methods
     # needed to adapt the stats to the superspace context.

--- a/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
+++ b/app/presenters/decidim/superspaces/superspace_stats_presenter.rb
@@ -2,6 +2,11 @@
 
 module Decidim
   module Superspaces
+    
+    # This class holds the logic to present superspace stats.
+    # It inherits from `Decidim::StatsPresenter` and overrides the methods
+    # needed to adapt the stats to the superspace context.
+
     class SuperspaceStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 

--- a/app/queries/decidim/superspaces/stats_followers_count.rb
+++ b/app/queries/decidim/superspaces/stats_followers_count.rb
@@ -3,6 +3,10 @@
 module Decidim
   module Superspaces
     class StatsFollowersCount < Decidim::Query
+
+      #This class is responsible for calculating the number of followers of a superspace.
+      #The number of followers in a superspace is equal to the sum of the number of followers in all the participatory spaces that belong to the superspace.
+      
       def self.for(superspace)
         return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
 

--- a/app/queries/decidim/superspaces/stats_followers_count.rb
+++ b/app/queries/decidim/superspaces/stats_followers_count.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    class StatsFollowersCount < Decidim::Query
+      def self.for(superspace)
+        return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
+
+        new(superspace).query
+      end
+
+      def initialize(superspace)
+        @superspace = superspace
+      end
+
+      def query
+        count=space_query + components_query
+
+        data = [{participatory_space: superspace.to_s, stat_title: "followers_count", stat_value: count}]
+
+        data.map do |d|
+           [d[:participatory_space].to_sym, d[:stat_title].to_sym, d[:stat_value].to_i]
+        end
+      end
+
+      private
+
+      attr_reader :superspace
+
+      def components_query
+        Decidim.component_manifests.sum do |component|
+          component.stats
+                   .filter(tag: :followers)
+                   .with_context(space_components)
+                   .map { |_name, value| value }
+                   .sum
+        end
+      end
+
+      def space_query
+        Decidim.participatory_space_manifests.sum do |space|
+          space.stats
+               .filter(tag: :followers)
+               .with_context(participatory_space_items)
+               .map { |_name, value| value }
+               .sum
+        end
+      end
+
+      def participatory_space_items
+        @participatory_space_items ||= superspace.participatory_spaces
+      end
+
+      def space_components
+        @space_components ||= Decidim::Component.where(participatory_space: participatory_space_items).published
+      end
+    end
+  end
+end

--- a/app/queries/decidim/superspaces/stats_followers_count.rb
+++ b/app/queries/decidim/superspaces/stats_followers_count.rb
@@ -3,10 +3,9 @@
 module Decidim
   module Superspaces
     class StatsFollowersCount < Decidim::Query
+      # This class is responsible for calculating the number of followers of a superspace.
+      # The number of followers in a superspace is equal to the sum of the number of followers in all the participatory spaces that belong to the superspace.
 
-      #This class is responsible for calculating the number of followers of a superspace.
-      #The number of followers in a superspace is equal to the sum of the number of followers in all the participatory spaces that belong to the superspace.
-      
       def self.for(superspace)
         return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
 

--- a/app/queries/decidim/superspaces/stats_followers_count.rb
+++ b/app/queries/decidim/superspaces/stats_followers_count.rb
@@ -14,12 +14,12 @@ module Decidim
       end
 
       def query
-        count=space_query + components_query
+        count = space_query + components_query
 
-        data = [{participatory_space: superspace.to_s, stat_title: "followers_count", stat_value: count}]
+        data = [{ participatory_space: superspace.to_s, stat_title: "followers_count", stat_value: count }]
 
         data.map do |d|
-           [d[:participatory_space].to_sym, d[:stat_title].to_sym, d[:stat_value].to_i]
+          [d[:participatory_space].to_sym, d[:stat_title].to_sym, d[:stat_value].to_i]
         end
       end
 

--- a/app/queries/decidim/superspaces/stats_participants_count.rb
+++ b/app/queries/decidim/superspaces/stats_participants_count.rb
@@ -135,33 +135,6 @@ module Decidim
           .uniq
       end
 
-      def assemblies_project_votes_query
-        Decidim::Budgets::Order.joins(budget: [:component])
-                               .where(budget: {
-                                        decidim_components: { id: assemblies_components.pluck(:id) }
-                                      })
-                               .pluck(:decidim_user_id)
-                               .uniq
-      end
-
-      def participatory_processes_project_votes_query
-        Decidim::Budgets::Order.joins(budget: [:component])
-                               .where(budget: {
-                                        decidim_components: { id: space_components.pluck(:id) }
-                                      })
-                               .pluck(:decidim_user_id)
-                               .uniq
-      end
-
-      def conferences_project_votes_query
-        Decidim::Budgets::Order.joins(budget: [:component])
-                               .where(budget: {
-                                        decidim_components: { id: conferences_components.pluck(:id) }
-                                      })
-                               .pluck(:decidim_user_id)
-                               .uniq
-      end
-
       def project_votes_query(components)
         return [] unless Decidim.module_installed?(:budgets)
 

--- a/app/queries/decidim/superspaces/stats_participants_count.rb
+++ b/app/queries/decidim/superspaces/stats_participants_count.rb
@@ -2,8 +2,12 @@
 
 module Decidim
   module Superspaces
-    # TODO: Change the name of the class to StatsParticipantsCount
     class StatsParticipantsCount < Decidim::Query
+
+      #This class is responsible for calculating the number of participants of a superspace.
+      #The number of participants in a superspace is equal to the sum of participants of the participatory spaces that belong to the superspace.
+      #If a user has participated in more than one participatory space, it will only be counted once.
+
       def self.for(superspace)
         return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
 
@@ -15,15 +19,35 @@ module Decidim
       end
 
       def query
+        participatory_process_class_name=Decidim::ParticipatoryProcess.class.name
+        assemblies_class_name=Decidim::Assembly.class.name
+        conferences_class_name=Decidim::Conference.class.name
+
         solution = [
-          comments_query,
-          debates_query,
-          meetings_query,
-          endorsements_query,
-          project_votes_query,
-          proposals_query,
-          proposal_votes_query,
-          survey_answer_query
+          comments_query(participatory_process_class_name, participatory_space_ids),
+          comments_query(assemblies_class_name, assemblies_ids),
+          comments_query(conferences_class_name, conferences_ids),
+          debates_query(space_components),
+          debates_query(assemblies_components),
+          debates_query(conferences_components),
+          meetings_query(space_components),
+          meetings_query(assemblies_components),
+          meetings_query(conferences_components),
+          endorsements_query(space_components),
+          endorsements_query(assemblies_components),
+          endorsements_query(conferences_components),
+          project_votes_query(space_components),
+          project_votes_query(assemblies_components),
+          project_votes_query(conferences_components),
+          proposals_query(proposals_components),
+          proposals_query(assemblies_proposals_components),
+          proposals_query(conferences_proposals_components),
+          proposal_votes_query(proposals_components),
+          proposal_votes_query(assemblies_proposals_components),
+          proposal_votes_query(conferences_proposals_components),
+          survey_answer_query(space_components),
+          survey_answer_query(assemblies_components),
+          survey_answer_query(conferences_components),
         ].flatten.uniq.count
 
         data = [{ participatory_space: @superspace.to_s, stat_title: "participants_count", stat_value: solution }]
@@ -35,10 +59,8 @@ module Decidim
 
       private
 
-      attr_reader :participatory_space
-
       def participatory_space_ids
-        @participatory_space_ids ||= @superspace.participatory_spaces.map(&:id)
+        @participatory_space_ids ||= @superspace.participatory_processes.map(&:id)
       end
 
       def assemblies_ids
@@ -49,141 +71,49 @@ module Decidim
         @conferences_ids ||= @superspace.conferences.map(&:id)
       end
 
-      def participatory_spaces_comments_query
-        Decidim::Comments::Comment
-          .where(decidim_participatory_space_type: Decidim::ParticipatoryProcess.class.name)
-          .where(decidim_participatory_space_id: participatory_space_ids)
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def assemblies_comments_query
-        Decidim::Comments::Comment
-          .where(decidim_participatory_space_type: Decidim::Assembly.class.name)
-          .where(decidim_participatory_space_id: assemblies_ids)
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def conferences_comments_query
-        Decidim::Comments::Comment
-          .where(decidim_participatory_space_type: Decidim::Conference.class.name)
-          .where(decidim_participatory_space_id: conferences_ids)
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def comments_query
+      def comments_query(class_name, ids)
         return [] unless Decidim.module_installed?(:comments)
 
-        [participatory_spaces_comments_query, assemblies_comments_query, conferences_comments_query].flatten.uniq
+        Decidim::Comments::Comment
+        .where(decidim_participatory_space_type: class_name)
+        .where(decidim_participatory_space_id: ids)
+        .pluck(:decidim_author_id)
+        .uniq
       end
 
-      def assemblies_debates_query
-        Decidim::Debates::Debate
-          .where(
-            component: assemblies_components,
-            decidim_author_type: Decidim::UserBaseEntity.name
-          )
-          .not_hidden
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def participatory_processes_debates_query
-        Decidim::Debates::Debate
-          .where(
-            component: space_components,
-            decidim_author_type: Decidim::UserBaseEntity.name
-          )
-          .not_hidden
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def conferences_debates_query
-        Decidim::Debates::Debate
-          .where(
-            component: conferences_components,
-            decidim_author_type: Decidim::UserBaseEntity.name
-          )
-          .not_hidden
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def debates_query
+      def debates_query(components)
         return [] unless Decidim.module_installed?(:debates)
 
-        [participatory_processes_debates_query, assemblies_debates_query, conferences_debates_query].flatten.uniq
+        Decidim::Debates::Debate
+        .where(
+          component: components,
+          decidim_author_type: Decidim::UserBaseEntity.name
+        )
+        .not_hidden
+        .pluck(:decidim_author_id)
+        .uniq
       end
 
-      def assemblies_meetings_query
-        assemblies_meetings = Decidim::Meetings::Meeting.where(component: assemblies_components).not_hidden
-        assemblies_registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: assemblies_meetings).distinct.pluck(:decidim_user_id)
-        assemblies_organizers = assemblies_meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
+      def meetings_query(components)
+        return [] unless Decidim.module_installed?(:meetings)
 
-        [assemblies_registrations, assemblies_organizers].flatten.uniq
-      end
-
-      def participatory_processes_meetings_query
-        meetings = Decidim::Meetings::Meeting.where(component: @space_components).not_hidden
+        meetings = Decidim::Meetings::Meeting.where(component: components).not_hidden
         registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: meetings).distinct.pluck(:decidim_user_id)
         organizers = meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
 
         [registrations, organizers].flatten.uniq
       end
 
-      def conferences_meetings_query
-        conferences_meetings = Decidim::Meetings::Meeting.where(component: conferences_components).not_hidden
-        conferences_registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: conferences_meetings).distinct.pluck(:decidim_user_id)
-        conferences_organizers = conferences_meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
-
-        [conferences_registrations, conferences_organizers].flatten.uniq
-      end
-
-      def meetings_query
-        return [] unless Decidim.module_installed?(:meetings)
-
-        [participatory_processes_meetings_query + assemblies_meetings_query + conferences_meetings_query].uniq
-      end
-
-      def assemblies_endorsements_query
+      def endorsements_query(components)
         Decidim::Endorsement
-          .where(resource: assemblies_components)
+          .where(resource: components)
           .pluck(:decidim_author_id)
           .uniq
       end
 
-      def participatory_processes_endorsements_query
-        Decidim::Endorsement
-          .where(resource: space_components)
-          .pluck(:decidim_author_id)
-          .uniq
-      end
+      def proposals_query(proposals_components)
+        return [] unless Decidim.module_installed?(:proposals)
 
-      def conferences_endorsements_query
-        Decidim::Endorsement
-          .where(resource: conferences_components)
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def endorsements_query
-        [participatory_processes_endorsements_query, assemblies_endorsements_query, conferences_endorsements_query].flatten.uniq
-      end
-
-      def assemblies_proposals_query
-        Decidim::Coauthorship
-          .where(
-            coauthorable: assemblies_proposals_components,
-            decidim_author_type: Decidim::UserBaseEntity.name
-          )
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def participatory_processes_proposals_query
         Decidim::Coauthorship
           .where(
             coauthorable: proposals_components,
@@ -193,56 +123,16 @@ module Decidim
           .uniq
       end
 
-      def conferences_proposals_query
-        Decidim::Coauthorship
-          .where(
-            coauthorable: conferences_proposals_components,
-            decidim_author_type: Decidim::UserBaseEntity.name
-          )
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def proposals_query
+      def proposal_votes_query(proposals_components)
         return [] unless Decidim.module_installed?(:proposals)
 
-        [participatory_processes_proposals_query, assemblies_proposals_query, conferences_proposals_query].flatten.uniq
-      end
-
-      def assemblies_proposal_votes_query
         Decidim::Proposals::ProposalVote
           .where(
-            proposal: assemblies_proposals_components
+            proposal: proposals_components,
           )
           .final
           .pluck(:decidim_author_id)
           .uniq
-      end
-
-      def participatory_processes_proposal_votes_query
-        Decidim::Proposals::ProposalVote
-          .where(
-            proposal: proposals_components
-          )
-          .final
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def conferences_proposal_votes_query
-        Decidim::Proposals::ProposalVote
-          .where(
-            proposal: conferences_proposals_components
-          )
-          .final
-          .pluck(:decidim_author_id)
-          .uniq
-      end
-
-      def proposal_votes_query
-        return [] unless Decidim.module_installed?(:proposals)
-
-        [participatory_processes_proposal_votes_query, assemblies_proposal_votes_query, conferences_proposal_votes_query].flatten.uniq
       end
 
       def assemblies_project_votes_query
@@ -272,26 +162,19 @@ module Decidim
                                .uniq
       end
 
-      def project_votes_query
+      def project_votes_query(components)
         return [] unless Decidim.module_installed?(:budgets)
 
-        [participatory_processes_project_votes_query, assemblies_project_votes_query, conferences_project_votes_query].flatten.uniq
+        Decidim::Budgets::Order.joins(budget: [:component])
+                               .where(budget: {
+                                        decidim_components: { id: components.pluck(:id) }
+                                      })
+                               .pluck(:decidim_user_id)
+                               .uniq
       end
 
-      def assemblies_survey_answer_query
-        Decidim::Forms::Answer.newsletter_participant_ids(assemblies_components)
-      end
-
-      def participatory_processes_survey_answer_query
-        Decidim::Forms::Answer.newsletter_participant_ids(space_components)
-      end
-
-      def conferences_survey_answer_query
-        Decidim::Forms::Answer.newsletter_participant_ids(conferences_components)
-      end
-
-      def survey_answer_query
-        [participatory_processes_survey_answer_query, assemblies_survey_answer_query, conferences_survey_answer_query].flatten.uniq
+      def survey_answer_query(components)
+        Decidim::Forms::Answer.newsletter_participant_ids(components)
       end
 
       def space_components

--- a/app/queries/decidim/superspaces/stats_participants_count.rb
+++ b/app/queries/decidim/superspaces/stats_participants_count.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Superspaces
     # TODO: Change the name of the class to StatsParticipantsCount
-    class StatsSuperspaceParticipantsCount < Decidim::Query
+    class StatsParticipantsCount < Decidim::Query
       def self.for(superspace)
         return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
 

--- a/app/queries/decidim/superspaces/stats_participants_count.rb
+++ b/app/queries/decidim/superspaces/stats_participants_count.rb
@@ -3,10 +3,9 @@
 module Decidim
   module Superspaces
     class StatsParticipantsCount < Decidim::Query
-
-      #This class is responsible for calculating the number of participants of a superspace.
-      #The number of participants in a superspace is equal to the sum of participants of the participatory spaces that belong to the superspace.
-      #If a user has participated in more than one participatory space, it will only be counted once.
+      # This class is responsible for calculating the number of participants of a superspace.
+      # The number of participants in a superspace is equal to the sum of participants of the participatory spaces that belong to the superspace.
+      # If a user has participated in more than one participatory space, it will only be counted once.
 
       def self.for(superspace)
         return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
@@ -19,9 +18,9 @@ module Decidim
       end
 
       def query
-        participatory_process_class_name=Decidim::ParticipatoryProcess.class.name
-        assemblies_class_name=Decidim::Assembly.class.name
-        conferences_class_name=Decidim::Conference.class.name
+        participatory_process_class_name = Decidim::ParticipatoryProcess.class.name
+        assemblies_class_name = Decidim::Assembly.class.name
+        conferences_class_name = Decidim::Conference.class.name
 
         solution = [
           comments_query(participatory_process_class_name, participatory_space_ids),
@@ -47,7 +46,7 @@ module Decidim
           proposal_votes_query(conferences_proposals_components),
           survey_answer_query(space_components),
           survey_answer_query(assemblies_components),
-          survey_answer_query(conferences_components),
+          survey_answer_query(conferences_components)
         ].flatten.uniq.count
 
         data = [{ participatory_space: @superspace.to_s, stat_title: "participants_count", stat_value: solution }]
@@ -75,23 +74,23 @@ module Decidim
         return [] unless Decidim.module_installed?(:comments)
 
         Decidim::Comments::Comment
-        .where(decidim_participatory_space_type: class_name)
-        .where(decidim_participatory_space_id: ids)
-        .pluck(:decidim_author_id)
-        .uniq
+          .where(decidim_participatory_space_type: class_name)
+          .where(decidim_participatory_space_id: ids)
+          .pluck(:decidim_author_id)
+          .uniq
       end
 
       def debates_query(components)
         return [] unless Decidim.module_installed?(:debates)
 
         Decidim::Debates::Debate
-        .where(
-          component: components,
-          decidim_author_type: Decidim::UserBaseEntity.name
-        )
-        .not_hidden
-        .pluck(:decidim_author_id)
-        .uniq
+          .where(
+            component: components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .not_hidden
+          .pluck(:decidim_author_id)
+          .uniq
       end
 
       def meetings_query(components)
@@ -128,7 +127,7 @@ module Decidim
 
         Decidim::Proposals::ProposalVote
           .where(
-            proposal: proposals_components,
+            proposal: proposals_components
           )
           .final
           .pluck(:decidim_author_id)

--- a/app/queries/decidim/superspaces/stats_superspace_participants_count.rb
+++ b/app/queries/decidim/superspaces/stats_superspace_participants_count.rb
@@ -1,0 +1,322 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    # TODO: Change the name of the class to StatsParticipantsCount
+    class StatsSuperspaceParticipantsCount < Decidim::Query
+      def self.for(superspace)
+        return 0 unless superspace.is_a?(Decidim::Superspaces::Superspace)
+
+        new(superspace).query
+      end
+
+      def initialize(superspace)
+        @superspace = superspace
+      end
+
+      def query
+        solution = [
+          comments_query,
+          debates_query,
+          meetings_query,
+          endorsements_query,
+          project_votes_query,
+          proposals_query,
+          proposal_votes_query,
+          survey_answer_query
+        ].flatten.uniq.count
+
+        data = [{ participatory_space: @superspace.to_s, stat_title: "participants_count", stat_value: solution }]
+
+        data.map do |d|
+          [d[:participatory_space].to_sym, d[:stat_title].to_sym, d[:stat_value].to_i]
+        end
+      end
+
+      private
+
+      attr_reader :participatory_space
+
+      def participatory_space_ids
+        @participatory_space_ids ||= @superspace.participatory_spaces.map(&:id)
+      end
+
+      def assemblies_ids
+        @assemblies_ids ||= @superspace.assemblies.map(&:id)
+      end
+
+      def conferences_ids
+        @conferences_ids ||= @superspace.conferences.map(&:id)
+      end
+
+      def participatory_spaces_comments_query
+        Decidim::Comments::Comment
+          .where(decidim_participatory_space_type: Decidim::ParticipatoryProcess.class.name)
+          .where(decidim_participatory_space_id: participatory_space_ids)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def assemblies_comments_query
+        Decidim::Comments::Comment
+          .where(decidim_participatory_space_type: Decidim::Assembly.class.name)
+          .where(decidim_participatory_space_id: assemblies_ids)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def conferences_comments_query
+        Decidim::Comments::Comment
+          .where(decidim_participatory_space_type: Decidim::Conference.class.name)
+          .where(decidim_participatory_space_id: conferences_ids)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def comments_query
+        return [] unless Decidim.module_installed?(:comments)
+
+        [participatory_spaces_comments_query, assemblies_comments_query, conferences_comments_query].flatten.uniq
+      end
+
+      def assemblies_debates_query
+        Decidim::Debates::Debate
+          .where(
+            component: assemblies_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .not_hidden
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def participatory_processes_debates_query
+        Decidim::Debates::Debate
+          .where(
+            component: space_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .not_hidden
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def conferences_debates_query
+        Decidim::Debates::Debate
+          .where(
+            component: conferences_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .not_hidden
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def debates_query
+        return [] unless Decidim.module_installed?(:debates)
+
+        [participatory_processes_debates_query, assemblies_debates_query, conferences_debates_query].flatten.uniq
+      end
+
+      def assemblies_meetings_query
+        assemblies_meetings = Decidim::Meetings::Meeting.where(component: assemblies_components).not_hidden
+        assemblies_registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: assemblies_meetings).distinct.pluck(:decidim_user_id)
+        assemblies_organizers = assemblies_meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
+
+        [assemblies_registrations, assemblies_organizers].flatten.uniq
+      end
+
+      def participatory_processes_meetings_query
+        meetings = Decidim::Meetings::Meeting.where(component: @space_components).not_hidden
+        registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: meetings).distinct.pluck(:decidim_user_id)
+        organizers = meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
+
+        [registrations, organizers].flatten.uniq
+      end
+
+      def conferences_meetings_query
+        conferences_meetings = Decidim::Meetings::Meeting.where(component: conferences_components).not_hidden
+        conferences_registrations = Decidim::Meetings::Registration.where(decidim_meeting_id: conferences_meetings).distinct.pluck(:decidim_user_id)
+        conferences_organizers = conferences_meetings.where(decidim_author_type: Decidim::UserBaseEntity.name).distinct.pluck(:decidim_author_id)
+
+        [conferences_registrations, conferences_organizers].flatten.uniq
+      end
+
+      def meetings_query
+        return [] unless Decidim.module_installed?(:meetings)
+
+        [participatory_processes_meetings_query + assemblies_meetings_query + conferences_meetings_query].uniq
+      end
+
+      def assemblies_endorsements_query
+        Decidim::Endorsement
+          .where(resource: assemblies_components)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def participatory_processes_endorsements_query
+        Decidim::Endorsement
+          .where(resource: space_components)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def conferences_endorsements_query
+        Decidim::Endorsement
+          .where(resource: conferences_components)
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def endorsements_query
+        [participatory_processes_endorsements_query, assemblies_endorsements_query, conferences_endorsements_query].flatten.uniq
+      end
+
+      def assemblies_proposals_query
+        Decidim::Coauthorship
+          .where(
+            coauthorable: assemblies_proposals_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def participatory_processes_proposals_query
+        Decidim::Coauthorship
+          .where(
+            coauthorable: proposals_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def conferences_proposals_query
+        Decidim::Coauthorship
+          .where(
+            coauthorable: conferences_proposals_components,
+            decidim_author_type: Decidim::UserBaseEntity.name
+          )
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def proposals_query
+        return [] unless Decidim.module_installed?(:proposals)
+
+        [participatory_processes_proposals_query, assemblies_proposals_query, conferences_proposals_query].flatten.uniq
+      end
+
+      def assemblies_proposal_votes_query
+        Decidim::Proposals::ProposalVote
+          .where(
+            proposal: assemblies_proposals_components
+          )
+          .final
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def participatory_processes_proposal_votes_query
+        Decidim::Proposals::ProposalVote
+          .where(
+            proposal: proposals_components
+          )
+          .final
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def conferences_proposal_votes_query
+        Decidim::Proposals::ProposalVote
+          .where(
+            proposal: conferences_proposals_components
+          )
+          .final
+          .pluck(:decidim_author_id)
+          .uniq
+      end
+
+      def proposal_votes_query
+        return [] unless Decidim.module_installed?(:proposals)
+
+        [participatory_processes_proposal_votes_query, assemblies_proposal_votes_query, conferences_proposal_votes_query].flatten.uniq
+      end
+
+      def assemblies_project_votes_query
+        Decidim::Budgets::Order.joins(budget: [:component])
+                               .where(budget: {
+                                        decidim_components: { id: assemblies_components.pluck(:id) }
+                                      })
+                               .pluck(:decidim_user_id)
+                               .uniq
+      end
+
+      def participatory_processes_project_votes_query
+        Decidim::Budgets::Order.joins(budget: [:component])
+                               .where(budget: {
+                                        decidim_components: { id: space_components.pluck(:id) }
+                                      })
+                               .pluck(:decidim_user_id)
+                               .uniq
+      end
+
+      def conferences_project_votes_query
+        Decidim::Budgets::Order.joins(budget: [:component])
+                               .where(budget: {
+                                        decidim_components: { id: conferences_components.pluck(:id) }
+                                      })
+                               .pluck(:decidim_user_id)
+                               .uniq
+      end
+
+      def project_votes_query
+        return [] unless Decidim.module_installed?(:budgets)
+
+        [participatory_processes_project_votes_query, assemblies_project_votes_query, conferences_project_votes_query].flatten.uniq
+      end
+
+      def assemblies_survey_answer_query
+        Decidim::Forms::Answer.newsletter_participant_ids(assemblies_components)
+      end
+
+      def participatory_processes_survey_answer_query
+        Decidim::Forms::Answer.newsletter_participant_ids(space_components)
+      end
+
+      def conferences_survey_answer_query
+        Decidim::Forms::Answer.newsletter_participant_ids(conferences_components)
+      end
+
+      def survey_answer_query
+        [participatory_processes_survey_answer_query, assemblies_survey_answer_query, conferences_survey_answer_query].flatten.uniq
+      end
+
+      def space_components
+        Decidim::Component.where(participatory_space: @superspace.participatory_processes)
+      end
+
+      def assemblies_components
+        Decidim::Component.where(participatory_space: @superspace.assemblies)
+      end
+
+      def conferences_components
+        Decidim::Component.where(participatory_space: @superspace.conferences)
+      end
+
+      def proposals_components
+        @proposals_components ||= Decidim::Proposals::FilteredProposals.for(space_components).published.not_hidden
+      end
+
+      def assemblies_proposals_components
+        @assemblies_proposals_components ||= Decidim::Proposals::FilteredProposals.for(assemblies_components).published.not_hidden
+      end
+
+      def conferences_proposals_components
+        @conferences_proposals_components ||= Decidim::Proposals::FilteredProposals.for(conferences_components).published.not_hidden
+      end
+    end
+  end
+end

--- a/app/views/decidim/superspaces/admin/superspaces/_form.html.erb
+++ b/app/views/decidim/superspaces/admin/superspaces/_form.html.erb
@@ -76,6 +76,9 @@
           </fieldset>
         </div>
       </div>
+       <div class="row column">
+        <%= form.check_box :show_statistics %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/decidim/superspaces/superspaces/show.html.erb
+++ b/app/views/decidim/superspaces/superspaces/show.html.erb
@@ -43,7 +43,7 @@
   <% end %>
 
   <% if superspace.show_statistics %>
-    <section id="processes-grid" class="layout-main__section layout-main__heading">
+    <section id="statistics-grid" class="layout-main__section layout-main__heading">
         <h2 class="title-decorator"><%= t("statistics", scope: "decidim.superspaces.superspaces.show") %></h2>
           <%= cell("decidim/statistics",superspace.statistics) %>
     </section>

--- a/app/views/decidim/superspaces/superspaces/show.html.erb
+++ b/app/views/decidim/superspaces/superspaces/show.html.erb
@@ -41,6 +41,13 @@
       <% end %>
     </section>
   <% end %>
+
+  <% if superspace.show_statistics %>
+    <section id="processes-grid" class="layout-main__section layout-main__heading">
+        <h2 class="title-decorator"><%= t("statistics", scope: "decidim.superspaces.superspaces.show") %></h2>
+          <%= cell("decidim/statistics",superspace.statistics) %>
+    </section>
+  <% end %>
 <% end %>
 
 <%= render partial: "language_selector" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,4 @@ en:
         show:
           assemblies: Assemblies
           participatory_processes: Participatory Processes
+          statistics: Statistics

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -57,3 +57,4 @@ es:
         show:
           assemblies: Asambleas
           participatory_processes: Procesos participativos
+          statistics: Estadísticas

--- a/db/migrate/20250218123528_add_show_statistics_to_decidim_superspaces_superspaces.rb
+++ b/db/migrate/20250218123528_add_show_statistics_to_decidim_superspaces_superspaces.rb
@@ -1,0 +1,5 @@
+class AddShowStatisticsToDecidimSuperspacesSuperspaces < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_superspaces_superspaces, :show_statistics, :boolean
+  end
+end

--- a/spec/commands/decidim/superspaces/admin/create_superspace_spec.rb
+++ b/spec/commands/decidim/superspaces/admin/create_superspace_spec.rb
@@ -18,6 +18,7 @@ module Decidim
         let(:participatory_process_ids) { nil }
         let(:conference_ids) { nil }
         let(:invalid) { false }
+        let(:show_statistics) { false }
         let(:form) do
           double(
             invalid?: invalid,
@@ -28,7 +29,8 @@ module Decidim
             locale:,
             assembly_ids:,
             participatory_process_ids:,
-            conference_ids:
+            conference_ids:,
+            show_statistics:,
           )
         end
 

--- a/spec/commands/decidim/superspaces/admin/create_superspace_spec.rb
+++ b/spec/commands/decidim/superspaces/admin/create_superspace_spec.rb
@@ -30,7 +30,7 @@ module Decidim
             assembly_ids:,
             participatory_process_ids:,
             conference_ids:,
-            show_statistics:,
+            show_statistics:
           )
         end
 

--- a/spec/commands/decidim/superspaces/admin/update_superspace_spec.rb
+++ b/spec/commands/decidim/superspaces/admin/update_superspace_spec.rb
@@ -31,7 +31,7 @@ module Decidim
             assembly_ids:,
             participatory_process_ids:,
             conference_ids:,
-            show_statistics:,
+            show_statistics:
           )
         end
 
@@ -69,7 +69,7 @@ module Decidim
           it "traces the action", :versioning do
             expect(Decidim.traceability)
               .to receive(:update!)
-              .with(superspace, current_user, { title: { en: title }, description: { en: description }, locale:, hero_image: , show_statistics: false })
+              .with(superspace, current_user, { title: { en: title }, description: { en: description }, locale:, hero_image:, show_statistics: false })
               .and_call_original
 
             expect { subject.call }.to change(Decidim::ActionLog, :count)

--- a/spec/commands/decidim/superspaces/admin/update_superspace_spec.rb
+++ b/spec/commands/decidim/superspaces/admin/update_superspace_spec.rb
@@ -19,6 +19,7 @@ module Decidim
         let(:assembly_ids) { nil }
         let(:participatory_process_ids) { nil }
         let(:conference_ids) { nil }
+        let(:show_statistics) { false }
         let(:form) do
           double(
             invalid?: invalid,
@@ -29,7 +30,8 @@ module Decidim
             locale:,
             assembly_ids:,
             participatory_process_ids:,
-            conference_ids:
+            conference_ids:,
+            show_statistics:,
           )
         end
 
@@ -67,7 +69,7 @@ module Decidim
           it "traces the action", :versioning do
             expect(Decidim.traceability)
               .to receive(:update!)
-              .with(superspace, current_user, { title: { en: title }, description: { en: description }, locale:, hero_image: })
+              .with(superspace, current_user, { title: { en: title }, description: { en: description }, locale:, hero_image: , show_statistics: false })
               .and_call_original
 
             expect { subject.call }.to change(Decidim::ActionLog, :count)

--- a/spec/system/superspaces_spec.rb
+++ b/spec/system/superspaces_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "User sees superspaces" do
   let!(:organization) { create(:organization) }
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
-  let!(:superspaces) { create_list(:superspace, 10, organization:) }
+  let!(:superspaces) { create_list(:superspace, 10, organization: , show_statistics: true) }
   let!(:assemblies) { create_list(:assembly, 10, organization:) }
   let!(:participatory_processes) { create_list(:participatory_process, 10, organization:) }
   let!(:assembly) { assemblies.first }
@@ -42,6 +42,9 @@ describe "User sees superspaces" do
       within all("#assemblies-grid").last do
         expect(page).to have_content("Assemblies")
       end
+      within all("#statistics-grid").last do
+        expect(page).to have_content("Statistics")
+      end
     end
   end
 
@@ -53,6 +56,15 @@ describe "User sees superspaces" do
     it "doesn't render grid if the superspace is empty" do
       expect(page).to have_no_selector("#processes-grid")
       expect(page).to have_no_selector("#assemblies-grid")
+      expect(page).to have_selector("#statistics-grid")
+    end
+
+    it "doesn't render statistics if the superspace show statistics is false" do
+      superspaces.last.update!(show_statistics: false)
+      visit decidim_superspaces.superspace_path(superspaces.last)
+
+      expect(page).to have_no_selector("#statistics-grid")
+
     end
   end
 end

--- a/spec/system/superspaces_spec.rb
+++ b/spec/system/superspaces_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "User sees superspaces" do
   let!(:organization) { create(:organization) }
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
-  let!(:superspaces) { create_list(:superspace, 10, organization: , show_statistics: true) }
+  let!(:superspaces) { create_list(:superspace, 10, organization:, show_statistics: true) }
   let!(:assemblies) { create_list(:assembly, 10, organization:) }
   let!(:participatory_processes) { create_list(:participatory_process, 10, organization:) }
   let!(:assembly) { assemblies.first }
@@ -56,7 +56,7 @@ describe "User sees superspaces" do
     it "doesn't render grid if the superspace is empty" do
       expect(page).to have_no_selector("#processes-grid")
       expect(page).to have_no_selector("#assemblies-grid")
-      expect(page).to have_selector("#statistics-grid")
+      expect(page).to have_css("#statistics-grid")
     end
 
     it "doesn't render statistics if the superspace show statistics is false" do
@@ -64,7 +64,6 @@ describe "User sees superspaces" do
       visit decidim_superspaces.superspace_path(superspaces.last)
 
       expect(page).to have_no_selector("#statistics-grid")
-
     end
   end
 end


### PR DESCRIPTION
Fixes #21 

- We implemented two classes, StatsParticipantsCount and StatsFollowersCount to get the number of participants and followers without duplicates. 
- We implemented a third class calles SuperspaceStatsPresenter to get all the participatory spaces stats