### PR TITLE
Remove permission action for not logged in

### DIFF
--- a/app/permissions/decidim/superspaces/permissions.rb
+++ b/app/permissions/decidim/superspaces/permissions.rb
@@ -4,7 +4,7 @@ module Decidim
   module Superspaces
     class Permissions < Decidim::DefaultPermissions
       def permissions
-        return permission_action unless user
+        # return permission_action unless user
         return Decidim::Superspaces::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
         superspace_action?


### PR DESCRIPTION
This PR will ultimately allow visitors that are not logged in to see the `superspaces` `index` and `show`.
Currently, these pagers redirect to the `sign in` page if not logged in.