### PR TITLE
Include superspaces content block for homepage

### DIFF
--- a/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell.rb
+++ b/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    module ContentBlocks
+      class HighlightedSuperspacesCell < Decidim::ContentBlocks::HighlightedParticipatorySpacesCell
+        delegate :current_user, to: :controller
+
+        def highlighted_spaces
+          @highlighted_spaces ||= Decidim::Superspaces::OrganizationSuperspaces
+                                  .new(current_organization)
+                                  .query
+        end
+
+        def i18n_scope
+          "decidim.superspaces.pages.home.highlighted_superspaces"
+        end
+
+        def all_path
+          Decidim::Superspaces::Engine.routes.url_helpers.superspaces_path
+        end
+
+        def max_results
+          model.settings.max_results
+        end
+
+        private
+
+        def block_id
+          "highlighted-superspaces"
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_settings_form/show.erb
+++ b/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+<% end %>

--- a/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_settings_form_cell.rb
+++ b/app/cells/decidim/superspaces/content_blocks/highlighted_superspaces_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    module ContentBlocks
+      class HighlightedSuperspacesSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.superspaces.admin.content_blocks.highlighted_superspaces.max_results")
+        end
+      end
+    end
+  end
+end

--- a/app/queries/decidim/superspaces/organization_superspaces.rb
+++ b/app/queries/decidim/superspaces/organization_superspaces.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Superspaces
+    # This query class filters all superspaces given an organization.
+    class OrganizationSuperspaces < Decidim::Query
+      def initialize(organization)
+        @organization = organization
+      end
+
+      def query
+        Decidim::Superspaces::Superspace.where(organization: @organization)
+      end
+    end
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -7,6 +7,8 @@ ignore_unused:
   - decidim.admin.menu.superspaces
   - decidim.superspaces.admin_log.*
   - decidim.superspaces.participatory_spaces.show.part_of
+  - decidim.superspaces.content_blocks.*
+  - decidim.superspaces.pages.home.highlighted_superspaces*
 
 ignore_missing:
   - decidim.participatory_processes.scopes.global

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
         models:
           superspace:
             name: Superspace
+        content_blocks:
+          highlighted_superspaces:
+            max_results: Maximum amount of elements to show
         superspaces:
           actions:
             confirm_destroy: Are you sure you want to delete this superspace?
@@ -37,6 +40,9 @@ en:
           create: "%{user_name} created the %{resource_name} superspace"
           delete: "%{user_name} deleted the %{resource_name} superspace"
           update: "%{user_name} updated the %{resource_name} superspace"
+      content_blocks:
+        highlighted_superspaces:
+          name: Highlighted superspaces
       models:
         superspace:
           fields:
@@ -46,6 +52,11 @@ en:
             locale: Language
             participatory_processes: Participatory Processes
             title: Title
+      pages:
+        home:
+          highlighted_superspaces: 
+            active_spaces: Active superspaces
+            see_all_spaces: See all superspaces
       participatory_spaces:
         show:
           part_of: This space is part of the %{superspace} superspace.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,12 +6,12 @@ en:
         superspaces: Superspaces
     superspaces:
       admin:
-        models:
-          superspace:
-            name: Superspace
         content_blocks:
           highlighted_superspaces:
             max_results: Maximum amount of elements to show
+        models:
+          superspace:
+            name: Superspace
         superspaces:
           actions:
             confirm_destroy: Are you sure you want to delete this superspace?
@@ -54,7 +54,7 @@ en:
             title: Title
       pages:
         home:
-          highlighted_superspaces: 
+          highlighted_superspaces:
             active_spaces: Active superspaces
             see_all_spaces: See all superspaces
       participatory_spaces:

--- a/lib/decidim/superspaces/content_blocks/content_blocks_homepage.rb
+++ b/lib/decidim/superspaces/content_blocks/content_blocks_homepage.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+def initialize_homepage_content_blocks
+  initializer "superspaces.content_blocks" do
+    Decidim.content_blocks.register(:homepage, :highlighted_superspaces) do |content_block|
+      content_block.cell = "decidim/superspaces/content_blocks/highlighted_superspaces"
+      content_block.settings_form_cell = "decidim/superspaces/content_blocks/highlighted_superspaces_settings_form"
+      content_block.public_name_key = "decidim.superspaces.content_blocks.highlighted_superspaces.name"
+
+      content_block.settings do |settings|
+        settings.attribute :max_results, type: :integer, default: 6
+      end
+    end
+  end
+end

--- a/lib/decidim/superspaces/engine.rb
+++ b/lib/decidim/superspaces/engine.rb
@@ -3,6 +3,8 @@
 require "rails"
 require "decidim/core"
 
+require_relative "content_blocks/content_blocks_homepage"
+
 module Decidim
   module Superspaces
     # This is the engine that runs on the public interface of superspaces.
@@ -30,6 +32,12 @@ module Decidim
       initializer "decidim_superspaces.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
+
+      initializer "decidim_superspaces.add_cells_view_paths" do
+        Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Superspaces::Engine.root}/app/cells")
+      end
+
+      initialize_homepage_content_blocks
     end
   end
 end

--- a/spec/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell_spec.rb
+++ b/spec/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Superspaces::ContentBlocks::HighlightedSuperspacesCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create(:content_block, organization:, manifest_name: :highlighted_superspaces, scope_name: :homepage, settings:) }
+  let!(:superspaces) { create_list(:superspace, 8, organization:) }
+  let(:settings) { {} }
+
+  let(:highlighted_superspaces) { subject.find_by(id: "highlighted-superspaces") }
+
+  controller Decidim::PagesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the content block has no settings" do
+    it "shows 6 superspaces" do
+      expect(highlighted_superspaces).to have_css("a.card__grid", count: 6)
+    end
+  end
+
+  context "when the content block has customized the max results setting value" do
+    let(:settings) do
+      {
+        "max_results" => "9"
+      }
+    end
+
+    it "shows up to 8 superspaces" do
+      expect(highlighted_superspaces).to have_css("a.card__grid", count: 8)
+    end
+  end
+end

--- a/spec/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell_spec.rb
+++ b/spec/cells/decidim/superspaces/content_blocks/highlighted_superspaces_cell_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Superspaces::ContentBlocks::HighlightedSuperspacesCell, type: 
   let!(:superspaces) { create_list(:superspace, 8, organization:) }
   let(:settings) { {} }
 
-  let(:highlighted_superspaces) { subject.find_by(id: "highlighted-superspaces") }
+  let(:highlighted_superspaces) { subject.find(id: "highlighted-superspaces") }
 
   controller Decidim::PagesController
 


### PR DESCRIPTION
Feature example:
![image](https://github.com/user-attachments/assets/eebf94d2-27bf-433e-8049-30e501b33765)
